### PR TITLE
Fix a couple of bugs in the ranchhand launcher script

### DIFF
--- a/modules/ranchhand/templates/launch_ranchhand.sh
+++ b/modules/ranchhand/templates/launch_ranchhand.sh
@@ -25,7 +25,7 @@ install_jq() {
   if ! command -v jq &> /dev/null; then
     local urlfrag="linux"
 
-    if [[ $distro == "darwin" ]]; then
+    if [[ $(uname -s) == "Darwin" ]]; then
       urlfrag="osx-amd"
     fi
     curl -sLo /usr/local/bin/jq "https://github.com/stedolan/jq/releases/download/jq-1.6/jq-$${urlfrag}64"


### PR DESCRIPTION
fixes:

- jq download URL was off
- jq binary was not executable
- jq artifact platform was coupled to `distro`