### PR TITLE
Add execute permission to jq

### DIFF
--- a/modules/ranchhand/templates/launch_ranchhand.sh
+++ b/modules/ranchhand/templates/launch_ranchhand.sh
@@ -23,12 +23,17 @@ ensure_workdir() {
 
 install_jq() {
   if ! command -v jq &> /dev/null; then
-    local urlfrag="linux"
 
-    if [[ $distro == "darwin" ]]; then
+    if [[ $distro == "darwin" ]]
+    then
       urlfrag="osx"
+      curl -sLo /usr/local/bin/jq "https://github.com/stedolan/jq/releases/download/jq-1.6/jq-$urlfrag-amd64"
+    elif [[ $distro == "linux" ]]
+    then
+      urlfrag="linux64"
+      curl -sLo /usr/local/bin/jq "https://github.com/stedolan/jq/releases/download/jq-1.6/jq-$urlfrag"
     fi
-    curl -sLo /usr/local/bin/jq "https://github.com/stedolan/jq/releases/download/jq-1.6/jq-$urlfrag-amd64"
+
     chmod +x /usr/local/bin/jq
 
     echo "installed tool: jq"


### PR DESCRIPTION
While running the deployer for pk8s, found that the local-exec tries to download the jq binary but doesnt have the relevant permission. 