### PR TITLE
PLAT-94: Add helm variables for ranchhand

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -369,4 +369,10 @@ module "ranchhand" {
   ssh_proxy_host = var.ssh_proxy_host
 
   admin_password = var.admin_password
+
+  helm_v3_registry_host = var.helm_v3_registry_host
+  helm_v3_registry_user = var.helm_v3_registry_user
+  helm_v3_registry_password = var.helm_v3_registry_password
+
+  newrelic_licensekey = var.newrelic_licensekey
 }

--- a/main.tf
+++ b/main.tf
@@ -353,7 +353,7 @@ resource "aws_security_group_rule" "provisioner_secgrp_ingress_443" {
 # Provisioner
 #------------------------------------------------------------------------------
 module "ranchhand" {
-  source = "github.com/dominodatalab/ranchhand?ref=v0.5.0"
+  source = "github.com/dominodatalab/ranchhand?ref=v0.6.0"
 
   node_ips = aws_instance.this.*.private_ip
 

--- a/main.tf
+++ b/main.tf
@@ -370,8 +370,8 @@ module "ranchhand" {
 
   admin_password = var.admin_password
 
-  helm_v3_registry_host = var.helm_v3_registry_host
-  helm_v3_registry_user = var.helm_v3_registry_user
+  helm_v3_registry_host     = var.helm_v3_registry_host
+  helm_v3_registry_user     = var.helm_v3_registry_user
   helm_v3_registry_password = var.helm_v3_registry_password
 
   newrelic_licensekey = var.newrelic_licensekey

--- a/variables.tf
+++ b/variables.tf
@@ -172,3 +172,19 @@ variable "rancher_version" {
   description = "Override for the installed Rancher version."
   default     = ""
 }
+
+variable "helm_v3_registry_host" {
+  default = ""
+}
+
+variable "helm_v3_registry_user" {
+  default = ""
+}
+
+variable "helm_v3_registry_password" {
+  default = ""
+}
+
+variable "newrelic_licensekey" {
+  default = ""
+}


### PR DESCRIPTION
Support to install newrelic monitoring on rancher nodes and k8s cluster.

[PLAT-94](https://dominodatalab.atlassian.net/browse/PLAT-94)