### PR TITLE
PLAT-1945: Require IMDSv2

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -36,6 +36,12 @@ resource "aws_instance" "this" {
     kms_key_id            = var.os_disk_kms_key_id
   }
 
+  metadata_options {
+    http_endpoint               = "enabled"
+    http_tokens                 = var.require_imdsv2 ? "required" : "optional"
+    http_put_response_hop_limit = 2
+  }
+
   tags = merge(
     var.tags,
     {

--- a/variables.tf
+++ b/variables.tf
@@ -188,3 +188,7 @@ variable "helm_v3_registry_password" {
 variable "newrelic_licensekey" {
   default = ""
 }
+
+variable "require_imdsv2" {
+  description = "Require instance metadata service v2"
+}


### PR DESCRIPTION
Require imdsv2 for access to the metadata endpoint.
Allow 2 hops so you can come from a container without needing a host port.