### PR TITLE
PLAT-7076: Update Ranchhand

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -359,7 +359,7 @@ resource "aws_security_group_rule" "provisioner_secgrp_ingress_443" {
 # Provisioner
 #------------------------------------------------------------------------------
 module "ranchhand" {
-  source = "github.com/dominodatalab/ranchhand?ref=v0.8.1"
+  source = "github.com/dominodatalab/ranchhand?ref=PLAT-7076"
 
   node_ips = aws_instance.this.*.private_ip
 

--- a/main.tf
+++ b/main.tf
@@ -359,7 +359,7 @@ resource "aws_security_group_rule" "provisioner_secgrp_ingress_443" {
 # Provisioner
 #------------------------------------------------------------------------------
 module "ranchhand" {
-  source = "github.com/dominodatalab/ranchhand?ref=PLAT-7076"
+  source = "github.com/dominodatalab/ranchhand?ref=v0.8.2"
 
   node_ips = aws_instance.this.*.private_ip
 


### PR DESCRIPTION
Updates Ranchhand to upgrade past RKE with a bug that can remove the cattle-system namespace when re-running "rke up"