### PR TITLE
Use version of ranchhand that disables ssh-agent

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -359,7 +359,7 @@ resource "aws_security_group_rule" "provisioner_secgrp_ingress_443" {
 # Provisioner
 #------------------------------------------------------------------------------
 module "ranchhand" {
-  source = "github.com/dominodatalab/ranchhand?ref=v1.1.0"
+  source = "github.com/dominodatalab/ranchhand?ref=ssh-slrn"
 
   node_ips = aws_instance.this.*.private_ip
 

--- a/main.tf
+++ b/main.tf
@@ -359,7 +359,7 @@ resource "aws_security_group_rule" "provisioner_secgrp_ingress_443" {
 # Provisioner
 #------------------------------------------------------------------------------
 module "ranchhand" {
-  source = "github.com/dominodatalab/ranchhand?ref=ssh-slrn"
+  source = "github.com/dominodatalab/ranchhand?ref=v1.1.1"
 
   node_ips = aws_instance.this.*.private_ip
 


### PR DESCRIPTION
We don't make use of SSH agent in any intentional way, however, it can cause problems when the loaded ssh keys increase the auth limit on proxied connections (or something along those lines).