### PR TITLE
Update ranchhand for openssl/cryptography compatibility fix

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -359,7 +359,7 @@ resource "aws_security_group_rule" "provisioner_secgrp_ingress_443" {
 # Provisioner
 #------------------------------------------------------------------------------
 module "ranchhand" {
-  source = "github.com/dominodatalab/ranchhand?ref=v1.1.1"
+  source = "github.com/dominodatalab/ranchhand?ref=PLAT-9082"
 
   node_ips = aws_instance.this.*.private_ip
 

--- a/main.tf
+++ b/main.tf
@@ -359,7 +359,7 @@ resource "aws_security_group_rule" "provisioner_secgrp_ingress_443" {
 # Provisioner
 #------------------------------------------------------------------------------
 module "ranchhand" {
-  source = "github.com/dominodatalab/ranchhand?ref=PLAT-9082"
+  source = "github.com/dominodatalab/ranchhand?ref=v1.1.2"
 
   node_ips = aws_instance.this.*.private_ip
 


### PR DESCRIPTION
Python cryptography is now enforcing the common name limit, so just leave it to the subject alt names only

See: https://github.com/pyca/cryptography/pull/11201