### PR TITLE
Ranchhand updates

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -359,7 +359,7 @@ resource "aws_security_group_rule" "provisioner_secgrp_ingress_443" {
 # Provisioner
 #------------------------------------------------------------------------------
 module "ranchhand" {
-  source = "github.com/dominodatalab/ranchhand?ref=v1.1.2"
+  source = "github.com/dominodatalab/ranchhand?ref=7758bbd3e18736f2971e2607996ce2af071ac9e2"
 
   node_ips = aws_instance.this.*.private_ip
 

--- a/main.tf
+++ b/main.tf
@@ -359,7 +359,7 @@ resource "aws_security_group_rule" "provisioner_secgrp_ingress_443" {
 # Provisioner
 #------------------------------------------------------------------------------
 module "ranchhand" {
-  source = "github.com/dominodatalab/ranchhand?ref=7758bbd3e18736f2971e2607996ce2af071ac9e2"
+  source = "github.com/dominodatalab/ranchhand?ref=v1.1.3"
 
   node_ips = aws_instance.this.*.private_ip
 


### PR DESCRIPTION
## Fix kubectl download URL and add RHEL package support

### Changes

- https://github.com/dominodatalab/ranchhand/pull/84
    - Replaces deprecated `storage.googleapis.com/kubernetes-release` with `dl.k8s.io` in the RKE ansible role
    - Updates for role to work on both Debian and RedHat host families.

### Context

The Kubernetes project has been migrating release artifacts away from the Google-owned `gs://kubernetes-release` GCS bucket to the community-managed `dl.k8s.io` endpoint. Newer patch releases are no longer published to the old URL.

- kubernetes/k8s.io#2396 — Deprecate and migrate away from `gs://kubernetes-release`
- kubernetes/kubernetes#117949 — Replace `storage.googleapis.com/kubernetes-release` references with `dl.k8s.io`